### PR TITLE
Remove trailing bracket in artifact name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<artifactId>libmatthew</artifactId>
 	<version>0.8.1</version>
 
-	<name>${project.artifactId}}</name>
+	<name>${project.artifactId}</name>
 
 	<description>
 		Some libraries from Matthew Johnson: http://www.matthew.ath.cx/projects/java/


### PR DESCRIPTION
Just came across your Maven-published version of Matthew's library and found a typo in the artifact name.
Looking at your repos, I realize you've been working on modernizing dbus-java recently. Too bad I did not find it before I started working on that on my own: https://github.com/sebkur/dbus-java